### PR TITLE
fix stream reconnect bug

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -194,9 +194,10 @@ func (r *marathonClient) registerSSESubscription() error {
 				continue
 			}
 			err = r.listenToSSE(stream)
-			if err != nil {
-				r.debugLog("Error on SSE subscription: %s", err)
+			if err == nil {
+				return
 			}
+			r.debugLog("Error on SSE subscription: %s", err)
 			stream.Close()
 		}
 	}()

--- a/subscription.go
+++ b/subscription.go
@@ -194,11 +194,12 @@ func (r *marathonClient) registerSSESubscription() error {
 				continue
 			}
 			err = r.listenToSSE(stream)
-			if err == nil {
-				return
-			}
-			r.debugLog("Error on SSE subscription: %s", err)
 			stream.Close()
+			if err != nil {
+				r.debugLog("Error on SSE subscription: %s. Reconnecting.", err)
+				continue
+			}
+			return
 		}
 	}()
 
@@ -246,7 +247,6 @@ func (r *marathonClient) listenToSSE(stream *eventsource.Stream) error {
 	for {
 		select {
 		case <-r.closeSSEStreamChan:
-			stream.Close()
 			return nil
 		case ev := <-stream.Events:
 			if err := r.handleEvent(ev.Data()); err != nil {
@@ -254,7 +254,6 @@ func (r *marathonClient) listenToSSE(stream *eventsource.Stream) error {
 			}
 		case err := <-stream.Errors:
 			return err
-
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes a bug with the stream closing PR. If you don't return from the `for` loop, it will loop back and try to reconnect.